### PR TITLE
iOS: Fixes fallback to UIWebView on iOS 8, preventing crashes. Fixes #156.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ionic cordova prepare               # re-install plugins compatible with cordova
 Install the WKWebViewPlugin:
 
 ```
-ionic cordova plugin add https://github.com/driftyco/cordova-plugin-wkwebview-engine.git --save
+ionic cordova plugin add https://github.com/ionic-team/cordova-plugin-wkwebview-engine.git --save
 ```
 
 **Note:** 

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -253,7 +253,7 @@ static void * KVOContext = &KVOContext;
 
     wkWebView.configuration.preferences.minimumFontSize = [settings cordovaFloatSettingForKey:@"MinimumFontSize" defaultValue:0.0];
     wkWebView.allowsLinkPreview = [settings cordovaBoolSettingForKey:@"AllowLinkPreview" defaultValue:NO];
-    wkWebView.scrollView.scrollEnabled = [settings cordovaFloatSettingForKey:@"ScrollEnabled" defaultValue:NO];
+    wkWebView.scrollView.scrollEnabled = [settings cordovaBoolSettingForKey:@"ScrollEnabled" defaultValue:NO];
     wkWebView.allowsBackForwardNavigationGestures = [settings cordovaBoolSettingForKey:@"AllowBackForwardNavigationGestures" defaultValue:NO];
 }
 

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -60,7 +60,7 @@
 {
     self = [super init];
     if (self) {
-        if (NSClassFromString(@"WKWebView") == nil) {
+        if (NSClassFromString(@"WKWebView") == nil || !IsAtLeastiOSVersion(@"9.0")) {
             return nil;
         }
         self.frame = frame;


### PR DESCRIPTION
### Platforms affected
iOS 8.x

### What does this PR do?
Fixes #156.
Fixes check which ensures fallback to UIWebView on iOS 8.x.

Prior to this change, the fallback to use UIWebView was:

    if (NSClassFromString(@"WKWebView") == nil) {
    
However, the `WKWebView` is present in iOS 8, it's just fatally flawed because of lack of access via the `file:///` protocol, hence can't be used for Apache Cordova applications. Hence the above condition evaluates to false, and the subsequent intialisation of WKWebView and GCDWebServer is carried out, causing the app to crash on iOS 8.x

By changing this line to:

    if (NSClassFromString(@"WKWebView") == nil || !IsAtLeastiOSVersion(@"9.0")) {
    
we ensure that the intialisation of WKWebView and GCDWebServer does not take place on iOS 8.x, ensuring that UIWebView is used.


### What testing has been done on this change?

Before the change:

    cordova create wkwebview-test && cd wkwebview-test
    cordova plugin add https://github.com/ionic-team/cordova-plugin-wkwebview-engine.git
    cordova platform add ios
    cordova run ios --target="iPhone-6, 8.4"    

Expected result: App runs and displays "Device ready" animation.

Actual result: App crashes as soon as it runs.


After the change:

    cordova create wkwebview-test && cd wkwebview-test
    cordova plugin add https://github.com/ionic-team/cordova-plugin-wkwebview-engine.git
    cordova platform add ios
    cordova run ios --target="iPhone-6, 8.4"    

Expected result: App runs and displays "Device ready" animation.

Actual result: App runs and displays "Device ready" animation. 
Background then foregrounding app works as expected: resume event fires and app doesn't crash in background.